### PR TITLE
feat!: port to v5.3.0 and 2.2081

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -1,20 +1,28 @@
 {
-  "geode": "4.10.2",
+  "geode": "5.3.0",
   "gd": {
-    "win": "2.2074",
-    "mac": "2.2074",
-    "ios": "2.2074",
-    "android": "2.2074"
+    "win": "2.2081",
+    "mac": "2.2081",
+    "ios": "2.2081",
+    "android": "2.2081"
   },
   "id": "zsa.edit-attempts",
   "name": "Edit Attempts",
-  "version": "v1.0.3",
+  "version": "v1.0.4",
   "developer": "ZSA",
+	"links": {
+		"source": "https://github.com/wlagos3/edit-attempts"
+	},
+  "repository": "https://github.com/wlagos3/edit-attempts",
   "description": "Set level attempts",
+	"issues": {
+		"info": "Message me on Discord if you find any issues @zsa_"
+	},
+	"tags": ["utility"],
   "resources": {
     "sprites": ["resources/editAttemptsButton.png"]
   },
   "dependencies": {
-    "geode.node-ids": ">=1.17.0"
+    "geode.node-ids": ">=1.23.0"
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,13 @@
 #include <Geode/modify/EditLevelLayer.hpp>
 #include <Geode/modify/LevelInfoLayer.hpp>
 #include <Geode/Geode.hpp>
+#include <Geode/ui/TextInput.hpp>
 
 using namespace geode::prelude;
 
-class ModifyAttemptCountPopup : public geode::Popup<GJGameLevel*> {
+class ModifyAttemptCountPopup : public geode::Popup {
     geode::SeedValueRSV* attempts;
-    CCTextInputNode* inputNode;
+    TextInput* inputNode;
     protected:
         bool boundsCheck(int num){
             if ((*attempts > 0 && num > std::numeric_limits<int>::max() - *attempts) ||
@@ -32,7 +33,7 @@ class ModifyAttemptCountPopup : public geode::Popup<GJGameLevel*> {
         }
         void onSetButtonClick(CCObject* sender){
             if(inputNode->getString().empty()){return;}
-            int val = geode::numFromString<int>(inputNode->getString()).unwrapOr(-1);
+            int val = numFromString<int>(inputNode->getString()).unwrapOr(-1);
             if (val > -1) {
                 setAttempts(val);
                 this->onClose(nullptr);
@@ -42,7 +43,7 @@ class ModifyAttemptCountPopup : public geode::Popup<GJGameLevel*> {
         }
         void onPlusButtonClick(CCObject* sender){
             if(inputNode->getString().empty()){return;}
-            int val = geode::numFromString<int>(inputNode->getString()).unwrapOr(-1);
+            int val = numFromString<int>(inputNode->getString()).unwrapOr(-1);
             if (val > -1) {
                 addAttempts(val);
                 this->onClose(nullptr);
@@ -52,7 +53,7 @@ class ModifyAttemptCountPopup : public geode::Popup<GJGameLevel*> {
         }
         void onMinusButtonClick(CCObject* sender){
             if(inputNode->getString().empty()){return;}
-            int val = geode::numFromString<int>(inputNode->getString()).unwrapOr(-1);
+            int val = numFromString<int>(inputNode->getString()).unwrapOr(-1);
             if (val > -1) {
                 subtractAttempts(val);
                 this->onClose(nullptr);
@@ -60,18 +61,16 @@ class ModifyAttemptCountPopup : public geode::Popup<GJGameLevel*> {
                 geode::Notification::create("Input is not a valid number", NotificationIcon::Error, 2.f)->show();
             }
         }
-        bool setup(GJGameLevel* level) override {
-            auto winSize = CCDirector::sharedDirector()->getWinSize();
+        bool init(GJGameLevel* level) {
+            if (!Popup::init(240.f, 160.f)) return false;
             attempts = &level->m_attempts;
 
             this->setTitle("Modify Attempt Count");
 
             auto menu = CCMenu::create();
 
-            auto input = CCTextInputNode::create(100, 100, "Attempts", "bigFont.fnt");
-            input->setScale(0.75);
-            input->setPosition(CCPoint(this->m_mainLayer->getContentWidth() / 2.f, 170 ));
-            input->setAllowedChars("0123456789");
+            auto input = TextInput::create(160.f, "Attempts");
+            input->setFilter("0123456789");
             inputNode = input;
 
             auto setSprite = ButtonSprite::create("Set");
@@ -97,16 +96,20 @@ class ModifyAttemptCountPopup : public geode::Popup<GJGameLevel*> {
             menu->addChildAtPosition(addButton, Anchor::Center, CCPoint(40, -50));
             menu->addChildAtPosition(removeButton, Anchor::Center, CCPoint(-39, -50));
             menu->updateLayout();
-            this->addChild(input);
-            this->addChild(menu);
+            this->m_mainLayer->addChildAtPosition(input, Anchor::Center, CCPoint(0.f, 15.f));
+            this->m_mainLayer->addChildAtPosition(menu, Anchor::Center, CCPoint(0.f, 15.f));
 
             return true;
+        }
+        void onClose(CCObject* sender) override {
+            inputNode->getInputNode()->detachWithIME();
+            Popup::onClose(sender);
         }
 
     public:
         static ModifyAttemptCountPopup* create(GJGameLevel* level) {
             auto ret = new ModifyAttemptCountPopup();
-            if (ret->initAnchored(240.f, 160.f, level)) {
+            if (ret->init(level)) {
                 ret->autorelease();
                 return ret;
             }
@@ -120,15 +123,11 @@ class $modify (AttemptSetterEditLevelLayer, EditLevelLayer){
 	void onAttemptSetButtonClick(CCObject* sender){
 		auto modifyAttemptCountPopup = ModifyAttemptCountPopup::create(m_level);
 		
-		modifyAttemptCountPopup->m_scene = this;
-        modifyAttemptCountPopup->m_noElasticity = true;
 		modifyAttemptCountPopup->show();
 	}
 	bool init(GJGameLevel* level){
 		if(!EditLevelLayer::init(level)) return false;
 
-		auto menu = CCMenu::create();
-		std::string input = std::to_string(level->m_attempts);
 		auto spr = CCSprite::create("editAttemptsButton.png"_spr);
 
 		auto folderMenu = getChildByID("folder-menu");
@@ -147,15 +146,11 @@ class $modify (AttemptSetterLevelInfoLayer, LevelInfoLayer){
 	void onAttemptSetButtonClick(CCObject* sender){
 		auto modifyAttemptCountPopup = ModifyAttemptCountPopup::create(m_level);
 		
-		modifyAttemptCountPopup->m_scene = this;
-        modifyAttemptCountPopup->m_noElasticity = true;
 		modifyAttemptCountPopup->show();
 	}
 	bool init(GJGameLevel* level, bool challenge){
 		if(!LevelInfoLayer::init(level, challenge)) return false;
 
-		auto menu = CCMenu::create();
-		std::string input = std::to_string(level->m_attempts);
 		auto spr = CCSprite::create("editAttemptsButton.png"_spr);
 
 
@@ -170,7 +165,6 @@ class $modify (AttemptSetterLevelInfoLayer, LevelInfoLayer){
 		return true;
 	}
 };
-
 
 
 


### PR DESCRIPTION
## Port to Geode v5.3.0 and GD 2.2081

### Changes

#### `mod.json`
- Bumped `geode` to `5.3.0`, GD target to `2.2081` on all platforms
- Bumped version to `v1.0.4`
- Bumped `geode.node-ids` dependency to `>=1.23.0`
- Added `repository`, `links.source`, `issues`, and `tags` metadata fields

#### `main.cpp`
- Migrated `Popup` from templated v4 API (`setup`/`initAnchored`) to v5 (`init`/`Popup::init`)
- Replaced `CCTextInputNode` with `geode::TextInput` and moved UI nodes to `m_mainLayer` 
  - fixes typing and button clicks not working
- Added `onClose` override with `detachWithIME()`
  - fixes being unable to type when reopening the popup
- Removed `m_scene`/`m_noElasticity` assignments and other dead code

### Testing

I've tested it on Windows, MacOS and iOS. Android32 and Android64 are untested.